### PR TITLE
Add @noSelfInFile for TypeScriptToLua

### DIFF
--- a/declarations/account.d.ts
+++ b/declarations/account.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 /**

--- a/declarations/achivement.d.ts
+++ b/declarations/achivement.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 /// <reference path="unit.d.ts" />
 

--- a/declarations/action.d.ts
+++ b/declarations/action.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 /// <reference path="ui.d.ts" />
 

--- a/declarations/activity.d.ts
+++ b/declarations/activity.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 /**

--- a/declarations/addon.d.ts
+++ b/declarations/addon.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 /**

--- a/declarations/archaeology.d.ts
+++ b/declarations/archaeology.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 /// <reference path="ui.d.ts" />
 

--- a/declarations/arena.d.ts
+++ b/declarations/arena.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 declare type ARENA_TEAM_GREEN = 0;

--- a/declarations/artifact.d.ts
+++ b/declarations/artifact.d.ts
@@ -1,1 +1,3 @@
+/** @noSelfInFile */
+
 // @todo: write declarations!

--- a/declarations/auction.d.ts
+++ b/declarations/auction.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 /// <reference path="item.d.ts" />
 

--- a/declarations/bank.d.ts
+++ b/declarations/bank.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /**
  * Map a bank item button or bag to an inventory slot button for use in inventory functions
  * @param buttodId bank item/bag ID.

--- a/declarations/barber.d.ts
+++ b/declarations/barber.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowFacialHairCustomizationGlobalType = "EARRINGS" | "FEATURES" | "HAIR" | "HORNS" | "MARKINGS" | "NORMAL" | "PIERCINGS" | "TUSKS";
 declare type WowFacialHairCustomizationType = "HORNS" | "NORMAL";
 

--- a/declarations/battlefield.d.ts
+++ b/declarations/battlefield.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowBattlefieldStatusType = "queued" | "confirm" | "active" | "none" | "error";
 declare type WowBattlefieldTeamSize = 0 | 2 | 3 | 5;
 declare type WowBattlefieldType = "ARENA" | "BATTLEGROUND" | "WARGAME";

--- a/declarations/binding.d.ts
+++ b/declarations/binding.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowCurrentBindingWhich = 1 | 2;
 declare type WowBindingSetType = 0 | WowCurrentBindingWhich;
 

--- a/declarations/blackMarket.d.ts
+++ b/declarations/blackMarket.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 interface C_BlackMarket {
 
     /**

--- a/declarations/buff.d.ts
+++ b/declarations/buff.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowBuffFilterType = "HELPFUL" | "HARMFUL" | "PLAYER" | "RAID" | "CANCELABLE" | "NOT_CANCELABLE";
 declare type WowBuffWeaponHandType = 1 | 2;
 declare type WowDebuffType = "Magic" | "Disease" | "Poison" | "Curse" | "";

--- a/declarations/calendar.d.ts
+++ b/declarations/calendar.d.ts
@@ -1,1 +1,3 @@
+/** @noSelfInFile */
+
 declare type WowCalendarEventType = "PLAYER" | "GUILD" | "ARENA" | "HOLIDAY" | "RAID_LOCKOUT";

--- a/declarations/camera.d.ts
+++ b/declarations/camera.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /**
  * Begin "Left click" in the 3D world
  * @protected

--- a/declarations/channel.d.ts
+++ b/declarations/channel.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowChannelChatType = "SAY" | "EMOTE" | "YELL" | "PARTY" | "GUILD" | "OFFICER" | "RAID" | "RAID_WARNING" | "INSTANCE_CHAT" | "WHISPER" | "CHANNEL" | "AFK" | "DND";
 declare type WowChannelLanguageId = 1 | 2 | 3 | 6 | 7 | 8 | 10 | 13 | 14 | 33 | 35 | 40 | 43 | 44;
 

--- a/declarations/character.d.ts
+++ b/declarations/character.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowCharacterTotemElementType = 1 | 2 | 3 | 4;
 declare type WowCharacterRestState = 0 | 1;
 declare type WowCharacterDeathkightRuneType = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/declarations/characterStatistics.d.ts
+++ b/declarations/characterStatistics.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare const CR_DEFENSE_SKILL = 2;
 declare const CR_DODGE = 3;
 declare const CR_PARRY = 4;

--- a/declarations/chatInfo.d.ts
+++ b/declarations/chatInfo.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowAddonMessageType = "PARTY" | "RAID" | "GUILD" | "BATTLEGROUND" | "WHISPER" | "CHANNEL";
 declare type WowChatFlag = "AFK" | "DND" | "GM";
 declare type WowChatJoinLeftType = "YOU_JOINED" | "YOU_LEFT" | "THROTTLED";

--- a/declarations/chatWindow.d.ts
+++ b/declarations/chatWindow.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare const AUTOCOMPLETE_FLAG_NONE = 0x00000000;
 declare const AUTOCOMPLETE_FLAG_IN_GROUP = 0x00000001;
 declare const AUTOCOMPLETE_FLAG_IN_GUILD = 0x00000002;

--- a/declarations/communication.d.ts
+++ b/declarations/communication.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowEmoteToken = "AGREE" | "AMAZE" | "ANGRY" | "APOLOGIZE" | "APPLAUD" | "ATTACKMYTARGET" | "BARK" | "BASHFUL" | "BECKON" |
     "BEG" | "BURP" | "BITE" | "BLEED" | "BLINK" | "KISS" | "BLUSH" | "BOGGLE" | "BONK" | "BORED" | "BOUNCE" | "BOW" | "BRB" | "BYE" | "CACKLE" |
     "CALM" | "SCRATCH" | "CHARGE" | "CHEER" | "EAT" | "CHICKEN" | "CHUCKLE" | "CLAP" | "COLD" | "COMFORT" | "COMMEND" | "CONFUSED" | "CONGRATULATE" |

--- a/declarations/companion.d.ts
+++ b/declarations/companion.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowCompanionType = "CRITTER" | "MOUNT";
 declare type WowMointType = 0x1 | 0x2 | 0x4 | 0x8 | 0x10;
 

--- a/declarations/constants.d.ts
+++ b/declarations/constants.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare const MAX_PLAYER_LEVEL_TABLE: {
     LE_EXPANSION_CLASSIC: 60,
     LE_EXPANSION_BURNING_CRUSADE: 70,

--- a/declarations/container.d.ts
+++ b/declarations/container.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 /// <reference path="item.d.ts" />
 /// <reference path="ui.d.ts" />

--- a/declarations/currency.d.ts
+++ b/declarations/currency.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type CurrencyLink = WowHyperlink;
 
 /**

--- a/declarations/cursor.d.ts
+++ b/declarations/cursor.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowCursorInfoType = "item" | "spell" | "macro" | "mount" | "money" | "merchant" | "battlepet";
 
 /**

--- a/declarations/debug.d.ts
+++ b/declarations/debug.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /**
  * Passes its arguments to the current print output handler. By default, this will output them all to the default chat frame
  * 

--- a/declarations/event.d.ts
+++ b/declarations/event.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowTypedEvents = {
 
     /**

--- a/declarations/global.d.ts
+++ b/declarations/global.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type EXPANSION_CLASSIC = 0;
 declare type EXPANSION_BURNING_CRUSADE = 1;
 declare type EXPANSION_WRATH_OF_THE_LICH_KING = 2;

--- a/declarations/gossip.d.ts
+++ b/declarations/gossip.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type QUEST_FREQUENCY_NORMAL = 1;
 declare type QUEST_FREQUENCY_DAILY = 2;
 declare type QUEST_FREQUENCY_WEEKLY = 3;

--- a/declarations/item.d.ts
+++ b/declarations/item.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type ITEM_QUALITY_GENERIC = -1;
 declare type ITEM_QUALITY_POOR = 0;
 declare type ITEM_QUALITY_COMMON = 1;

--- a/declarations/quest.d.ts
+++ b/declarations/quest.d.ts
@@ -1,1 +1,3 @@
+/** @noSelfInFile */
+
 declare type WowQuestType = "required" | "reward" | "choice";

--- a/declarations/security.d.ts
+++ b/declarations/security.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 /**

--- a/declarations/system.d.ts
+++ b/declarations/system.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /**
  * Execute a console command
  * 

--- a/declarations/ui.d.ts
+++ b/declarations/ui.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 /// <reference path="global.d.ts" />
 
 declare type WowHorizontalAlign = "LEFT" | "CENTER" | "RIGHT";

--- a/declarations/unit.d.ts
+++ b/declarations/unit.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare type WowUnitIdArena = "arena1" | "arena2" | "arena3" | "arena4" | "arena5"
 declare type WowUnitIdRaidPlayer = "raid1" | "raid2" | "raid3" | "raid4" | "raid5" | "raid6" | "raid7" | "raid8" | "raid9" |
     "raid10" | "raid11" | "raid12" | "raid13" | "raid14" | "raid15" | "raid16" | "raid17" | "raid18" | "raid19" | "raid20" |


### PR DESCRIPTION
Not sure how you feel about this, but it is required to use these types with TSTL.

Otherwise TSTL makes all function calls take a "this" param as the first argument (it uses `_G` in global case, but it makes all global function calls fail without it).

e.g. ts `CreateFrame(a)` becomes lua `CreateFrame(_G, a)`, which fails.

This should only be temporary.. TypeScriptToLua/TypeScriptToLua#718 should fix it

I promise I'll do the work to remove all these comments, once TSTL implements the `--noSelf` option.