### PR TITLE
fix "TS2304: Cannot find name 'AtlasID'."

### DIFF
--- a/declarations/classes/C_Spell.d.ts
+++ b/declarations/classes/C_Spell.d.ts
@@ -9,7 +9,7 @@ declare namespace C_Spell {
      * @see https://wow.gamepedia.com/API_C_Spell.GetMawPowerBorderAtlasBySpellID
      * @since 9.0.2 (2020-11-17)
      */
-    function GetMawPowerBorderAtlasBySpellID(spellId: number): AtlasID;
+    function GetMawPowerBorderAtlasBySpellID(spellId: number): WoWAPI.AtlasID;
 
     /**
      * Needs summary


### PR DESCRIPTION
Hello, an error occured when I try to run "npx tstl" with typescript-to-lua:
```
node_modules/@wartoshika/wow-declarations/declarations/classes/C_Spell.d.ts:12:64 - error TS2304: Cannot find name 'AtlasID'.

12     function GetMawPowerBorderAtlasBySpellID(spellId: number): AtlasID;
                                                                  ~~~~~~~
```
and this pull request may fix it.